### PR TITLE
changed finding admin to by username so he can change his email from the webapp

### DIFF
--- a/api/hooks/permissions/index.js
+++ b/api/hooks/permissions/index.js
@@ -107,7 +107,7 @@ class Permissions extends Marlinspike {
         return require(path.resolve(fixturesPath, 'user')).create(this.roles, userModel)
       })
       .then(() => {
-        return sails.models.user.findOne({ email: this.sails.config.permissions.adminEmail })
+        return sails.models.user.findOne({ username: this.sails.config.permissions.adminUsername })
       })
       .then(user => {
         this.sails.log('sails-permissions: created admin user:', user)


### PR DESCRIPTION
This commit adds the ability for the admin to change his email and password from the web application. so only the username needs to be the same as the configured one.