### PR TITLE
Add capability to list all permissions

### DIFF
--- a/api/services/PermissionService.js
+++ b/api/services/PermissionService.js
@@ -357,6 +357,28 @@ module.exports = {
         });
       });
   },
+  
+  getAllPermissions: function(){
+    ok = Promise.resolve();
+    ok = ok.then(function(){
+      return Permission.find()
+      .populate('role')
+      .populate('model')
+    });
+    
+    ok = ok.then(function(permissions){
+      var results;
+      permissions.forEach(permission, index, permissions){
+        results.push({
+          model: permission.model.name,
+          role: permission.role.name,
+          action: permission.action
+        });
+      }
+      return results
+    });
+    return ok
+  }
 
   /**
    * revoke permission from role


### PR DESCRIPTION
I should warn I'm fairly new to the concept of promises (usually just use callbacks).

I could use some assistance with this as I'm not sure how the promises are used when they come out of the service.

If I do a PermissionService.getAllPermissions.then(function(result) {console.log(result)}) on the first ok.then call, it prints the correct information, but I am not sure if that is the desired output.  So I added the 2nd ok.then on top of it to only return the relative information (model the permission is on, the role associated, and action allowed).  I for some reason can't get it to return the collection in my console when I do PermissionService.getAllPermissions, and I'm not sure what I'm doing wrong.

This is a pull request because I feel there should be a way for admins to see what permissions have been granted to what roles easily.